### PR TITLE
Initial FastAPI weather API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,24 @@
 # fastApiDemo
-Demo repo for Python FastAPI
+
+Simple FastAPI demo providing mock weather data.
+
+## Setup
+
+Install dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Running
+
+Start the server with Uvicorn:
+
+```bash
+uvicorn app.main:app --reload
+```
+
+The API exposes:
+
+- `GET /health` - health check
+- `GET /weather/{city}` - weather data for a city

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,31 @@
+import logging
+from fastapi import FastAPI, HTTPException
+from .models import WeatherData
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO)
+
+app = FastAPI(title="Weather API")
+
+# mock weather data
+MOCK_WEATHER = {
+    "London": WeatherData(city="London", temperature=15.0, condition="Cloudy"),
+    "New York": WeatherData(city="New York", temperature=20.0, condition="Sunny"),
+}
+
+@app.get("/health")
+async def health() -> dict:
+    """Health check endpoint."""
+    logger.info("Health check")
+    return {"status": "ok"}
+
+@app.get("/weather/{city}", response_model=WeatherData)
+async def get_weather(city: str) -> WeatherData:
+    """Return weather data for a given city."""
+    logger.info("Weather request for %s", city)
+    try:
+        data = MOCK_WEATHER[city]
+    except KeyError as exc:
+        logger.error("Weather data not found for %s", city)
+        raise HTTPException(status_code=404, detail="City not found") from exc
+    return data

--- a/app/models.py
+++ b/app/models.py
@@ -1,0 +1,6 @@
+from pydantic import BaseModel
+
+class WeatherData(BaseModel):
+    city: str
+    temperature: float
+    condition: str

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+fastapi
+uvicorn


### PR DESCRIPTION
## Summary
- add Weather model and API routes
- add FastAPI app and logging
- provide setup instructions and dependencies

## Testing
- `pip install -r requirements.txt`
- `uvicorn app.main:app --port 8000 --log-level info & PID=$!; sleep 2; curl -s http://localhost:8000/health; kill $PID`
- `uvicorn app.main:app --port 8000 --log-level info & PID=$!; sleep 2; curl -s http://localhost:8000/weather/London; curl -s -o /tmp/out http://localhost:8000/weather/Invalid; cat /tmp/out; kill $PID`


------
https://chatgpt.com/codex/tasks/task_e_683f70cc5cf88322b894e40a64e13b47